### PR TITLE
Fix/lower case repository name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/main')
     env:
       TAG_IMAGE_LATEST: "true"
-      PROD_IMAGE_NAME: ghcr.io/${GITHUB_REPOSITORY}
+      PROD_IMAGE_NAME: ghcr.io/${GITHUB_REPOSITORY,,}
       VERSION: ${GITHUB_SHA}
     needs: [check, unit-test, integration-test-cli, integration-test-k8s, helm-chart-test]
     name: Release images
@@ -123,7 +123,7 @@ jobs:
     # Only on tags.
     if: startsWith(github.ref, 'refs/tags/')
     env:
-      PROD_IMAGE_NAME: ghcr.io/${GITHUB_REPOSITORY}
+      PROD_IMAGE_NAME: ghcr.io/${GITHUB_REPOSITORY,,}
     needs: [check, unit-test, integration-test-cli, integration-test-k8s, helm-chart-test]
     name: Tagged release images
     runs-on: ubuntu-latest

--- a/.github/workflows/helmrelease.yaml
+++ b/.github/workflows/helmrelease.yaml
@@ -27,7 +27,7 @@ jobs:
           version: v3.7.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: deploy/kubernetes/helm
         env:


### PR DESCRIPTION
CI failing due to uppercase S in repository name: [failing action](https://github.com/Smartum/sloth/actions/runs/12231144750/job/34113732889)